### PR TITLE
Fix issue with tooltip overflow

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   }, []);
   
   return (<>
-      <div> Still in development...
+      <div> This is the dev branch.
       </div>
       <div>{loading ? `loading...` : testString}</div>
       {/* <IconList/> */}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   }, []);
   
   return (<>
-      <div> This is the login page, but it's still in development...
+      <div> {`This is the login page, but it's still in development...`}
       </div>
       <div>{loading ? `loading...` : testString}</div>
       {/* <IconList/> */}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -24,7 +24,7 @@ const LoginPage = () => {
   }, []);
   
   return (<>
-      <div> This is the dev branch.
+      <div> This is the login page, but it's still in development...
       </div>
       <div>{loading ? `loading...` : testString}</div>
       {/* <IconList/> */}

--- a/app/store/tradeWindow.tsx
+++ b/app/store/tradeWindow.tsx
@@ -164,10 +164,12 @@ const TradeWindowComponent = ({costMultiplier}: {costMultiplier: number}) => {
 	}
 	
 	return (<>
-		<div>{tradeWindowMessage}</div>
-		<div className="w-full">
-		{renderInventoryItem()}
-		{renderQuantityButtons()}
+		<div className={`my-8`}>
+			<div>{tradeWindowMessage}</div>
+			<div className="w-full">
+			{renderInventoryItem()}
+			{renderQuantityButtons()}
+			</div>
 		</div>
 	</>);
 }

--- a/backend/testing/environmentTest.ts
+++ b/backend/testing/environmentTest.ts
@@ -1,3 +1,3 @@
 export class environmentTest {
-	static testKey = process.env.TEST_ENV_KEY;
+	static testKey = process.env.TEST_ENV_KEY || 'key not found';
 }


### PR DESCRIPTION
Tooltips now no longer overflow out of the window; a tooltip that would be above the screen now appears below the child element.